### PR TITLE
Improvements to gruffalo-standalone.sh and integration to supervisor

### DIFF
--- a/gruffalo-standalone.sh
+++ b/gruffalo-standalone.sh
@@ -2,4 +2,13 @@
 
 mvn dependency:build-classpath -Dmdep.outputFile=classpath -q
 CLASSPATH=target/classes:`cat classpath`
-java -cp $CLASSPATH -Xmx2024m -Xms2024m com.outbrain.gruffalo.StandaloneGruffaloServer "$@"
+# run com.outbrain.gruffalo.StandaloneGruffaloServer -h to check available args and usage
+# change port and cluster before starting
+java \
+  -cp $CLASSPATH \
+  -Djava.net.preferIPv4Stack=true \
+  -Xmx2024m \
+  -Xms2024m \
+  com.outbrain.gruffalo.StandaloneGruffaloServer \
+  --port 2003 \
+  --cluster node01:2003,node02:2003,node03:2003

--- a/supervisor/gruffalo.conf
+++ b/supervisor/gruffalo.conf
@@ -1,0 +1,9 @@
+[program:gruffalo]
+command=/gruffalo/gruffalo-standalone.sh
+stdout_logfile=/var/log/gruffalo.log
+directory=/gruffalo
+user=root
+autostart=true
+autorestart=true
+redirect_stderr=True
+stopasgroup=true


### PR DESCRIPTION
# gruffalo-standalone.sh
* Added Djava.net.preferIPv4Stack=true to force java to listen IPv4
* Added comment about -h 
*  Improved readability
*  Added required args to run java command
# supervisor integration
* Added stopasgroup=true  supervisor can kill java spawned process
* logs are at /var/log